### PR TITLE
[Feat] 공지사항의 FB연결, 프로필 수정관련 예외처리

### DIFF
--- a/TteoPpoKki4U/TteoPpoKki4U.xcodeproj/project.pbxproj
+++ b/TteoPpoKki4U/TteoPpoKki4U.xcodeproj/project.pbxproj
@@ -249,7 +249,7 @@
 		61FCFDAE2C310E6700B417A0 /* BlockManageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockManageViewController.swift; sourceTree = "<group>"; };
 		61FCFDB02C31111000B417A0 /* BlockedUserCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserCell.swift; sourceTree = "<group>"; };
 		8D1410002C12BF900062E527 /* UIResponder+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extension.swift"; sourceTree = "<group>"; };
-		8D1427D62C326F4C005505DC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		8D1427D62C326F4C005505DC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		8D2E862C2C1AD5DD00967B13 /* BookmarkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewModel.swift; sourceTree = "<group>"; };
 		8D2E862E2C1B2D7000967B13 /* BookmarkList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkList.swift; sourceTree = "<group>"; };
 		8D3BA8402C15D5F1007597F2 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };

--- a/TteoPpoKki4U/TteoPpoKki4U/View/Map/MapViewController.swift
+++ b/TteoPpoKki4U/TteoPpoKki4U/View/Map/MapViewController.swift
@@ -359,9 +359,9 @@ class MapViewController: UIViewController, PinStoreViewDelegate {
     
     private func customAlertControl() {
         if storeInfoView.isScrapped {
-            showCustomAlert(image: UIImage(systemName: "flag.fill")!, message: "스크랩되었습니다.")
+            showPositiveCustomAlert(image: UIImage(systemName: "flag.fill")!, message: "스크랩되었습니다.")
         } else {
-            showCustomAlert(image: UIImage(systemName: "flag.slash")!, message: "스크랩이 해제되었습니다.")
+            showNegativeCustomAlert(image: UIImage(systemName: "flag.slash")!, message: "스크랩이 해제되었습니다.")
         }
     }
     

--- a/TteoPpoKki4U/TteoPpoKki4U/View/RecommendPage/CustomAlertViewController.swift
+++ b/TteoPpoKki4U/TteoPpoKki4U/View/RecommendPage/CustomAlertViewController.swift
@@ -16,7 +16,7 @@ class CustomAlertViewController: UIViewController {
     }
 }
 extension UIViewController {
-    @objc func showCustomAlert(image: UIImage, message: String) {
+    @objc func showPositiveCustomAlert(image: UIImage, message: String) {
         print(#function)
         if let existingAlertView = view.subviews.first(where: { $0.tag == 999 }) {
             existingAlertView.removeFromSuperview()
@@ -26,6 +26,75 @@ extension UIViewController {
         let customAlertView = UIView()
         customAlertView.tag = 999
         customAlertView.backgroundColor = ThemeColor.mainOrange
+        customAlertView.tintColor = .white
+        customAlertView.layer.cornerRadius = 8
+        customAlertView.layer.shadowColor = UIColor.black.cgColor
+        customAlertView.layer.shadowOpacity = 0.3
+        customAlertView.layer.shadowOffset = CGSize(width: 0, height: 5)
+        customAlertView.layer.shadowRadius = 8
+        
+        // 이미지 뷰 설정
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        customAlertView.addSubview(imageView)
+        
+        // 메시지 레이블 설정
+        let messageLabel = UILabel()
+        messageLabel.text = message
+        messageLabel.textColor = .white
+        messageLabel.font = UIFont(name: "Pretendard-Regular", size: 14)
+        messageLabel.textAlignment = .center
+        messageLabel.numberOfLines = 0
+        customAlertView.addSubview(messageLabel)
+        
+        self.view.addSubview(customAlertView)
+        
+        // 제약 조건 설정
+        imageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(10)
+            make.centerY.equalToSuperview()
+            make.width.equalTo(image.size.width)
+            make.height.equalTo(image.size.height)
+        }
+        messageLabel.snp.makeConstraints { make in
+            make.leading.equalTo(imageView.snp.trailing).offset(10)
+            make.trailing.equalToSuperview().inset(10)
+            make.centerY.equalToSuperview()
+        }
+        
+        customAlertView.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-10)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(max(image.size.height, 40))
+            make.width.equalTo(image.size.width + messageLabel.intrinsicContentSize.width + 40)
+        }
+        
+        // 알럿 크기를 조절합니다.
+        customAlertView.transform = CGAffineTransform(scaleX: 0.98, y: 0.98)
+        
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
+            customAlertView.transform = .identity
+        }, completion: { _ in
+            Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { _ in
+                UIView.animate(withDuration: 0.3, animations: {
+                    customAlertView.alpha = 0
+                }, completion: { _ in
+                    customAlertView.removeFromSuperview()
+                })
+            }
+        })
+    }
+    
+    @objc func showNegativeCustomAlert(image: UIImage, message: String) {
+        print(#function)
+        if let existingAlertView = view.subviews.first(where: { $0.tag == 999 }) {
+            existingAlertView.removeFromSuperview()
+        }
+        
+        // 사용자 정의 팝업 뷰를 만듭니다.
+        let customAlertView = UIView()
+        customAlertView.tag = 999
+        customAlertView.backgroundColor = .gray
         customAlertView.tintColor = .white
         customAlertView.layer.cornerRadius = 8
         customAlertView.layer.shadowColor = UIColor.black.cgColor

--- a/TteoPpoKki4U/TteoPpoKki4U/View/RecommendPage/DetailViewController.swift
+++ b/TteoPpoKki4U/TteoPpoKki4U/View/RecommendPage/DetailViewController.swift
@@ -165,7 +165,7 @@ class DetailViewController: UIViewController, UISearchBarDelegate {
                 }
                 let bookmark0Image = UIImageView()
                 bookmark0Image.image = .bookmark0
-                showCustomAlert(image: bookmark0Image.image!, message: "북마크에서 삭제 되었어요.")
+                showNegativeCustomAlert(image: bookmark0Image.image!, message: "북마크에서 삭제 되었어요.")
                 viewModel.deleteBookmarkItem(title: titleLabel.text!)
             } else {
                 if let image = UIImage(named: "bookmark1")?.withRenderingMode(.alwaysTemplate) {
@@ -174,13 +174,13 @@ class DetailViewController: UIViewController, UISearchBarDelegate {
                 }
                 let bookmark1Image = UIImageView()
                 bookmark1Image.image = .bookmark1
-                showCustomAlert(image: bookmark1Image.image!, message: "북마크에 추가 되었어요.")
+                showPositiveCustomAlert(image: bookmark1Image.image!, message: "북마크에 추가 되었어요.")
                 viewModel.createBookmarkItem(title: titleLabel.text!, imageURL: imageURL.text!)
             }
         } else {
             let userXImage = UIImageView()
             userXImage.image = .userX
-            showCustomAlert(image: userXImage.image!, message: "로그인이 필요한 기능입니다.")
+            showPositiveCustomAlert(image: userXImage.image!, message: "로그인이 필요한 기능입니다.")
         }
     }
     private func bind() {
@@ -339,7 +339,7 @@ class DetailViewController: UIViewController, UISearchBarDelegate {
         
         let clipBoardImage = UIImageView()
         clipBoardImage.image = UIImage(named: "clipBoard")
-        showCustomAlert(image: clipBoardImage.image!, message: "복사를 완료했어요.")
+        showPositiveCustomAlert(image: clipBoardImage.image!, message: "복사를 완료했어요.")
     }
 }
 extension DetailViewController: UICollectionViewDataSource {

--- a/TteoPpoKki4U/TteoPpoKki4U/View/RecommendPage/RecommendCardView.swift
+++ b/TteoPpoKki4U/TteoPpoKki4U/View/RecommendPage/RecommendCardView.swift
@@ -134,19 +134,19 @@ public class MyCardCell: CardCell {
                 viewModel.deleteBookmarkItem(title: titleLabel.text!)
                 let bookmark0Image = UIImageView()
                 bookmark0Image.image = .bookmark0
-                viewController.showCustomAlert(image: bookmark0Image.image!, message: "북마크에서 삭제 되었어요.")
+                viewController.showNegativeCustomAlert(image: bookmark0Image.image!, message: "북마크에서 삭제 되었어요.")
                 
             } else {
                 bookmarkButton.setImage(.bookmark1, for: .normal)
                 viewModel.createBookmarkItem(title: titleLabel.text!, imageURL: imageURL.text!)
                 let bookmark1Image = UIImageView()
                 bookmark1Image.image = .bookmark1
-                viewController.showCustomAlert(image: bookmark1Image.image!, message: "북마크에 추가 되었어요.")
+                viewController.showPositiveCustomAlert(image: bookmark1Image.image!, message: "북마크에 추가 되었어요.")
             }
         } else {
             let userXImage = UIImageView()
             userXImage.image = .userX
-            viewController.showCustomAlert(image: userXImage.image!, message: "로그인이 필요한 기능입니다.")
+            viewController.showPositiveCustomAlert(image: userXImage.image!, message: "로그인이 필요한 기능입니다.")
         }
     }
     


### PR DESCRIPTION
[Feat] 공지사항의 FB연결, 프로필 수정관련 예외처리

1. 공지사항을 FB와 연결하여 실시간으로 공지사항의 작성 및 삭제가능
2. 프로필 수정 관련
- 닉네임의 변경 없이 프로필 사진만 변경할 경우에 프로필을 저장할 수 없는 예외 상황에 대한 처리 